### PR TITLE
Record the author date of commits in the Commit struct

### DIFF
--- a/blame/blame_test.go
+++ b/blame/blame_test.go
@@ -1,10 +1,9 @@
 package blame
 
 import (
-	"github.com/kr/pretty"
 	"reflect"
-	"strings"
 	"testing"
+	"time"
 )
 
 var testRepoDir = "../goblametest"
@@ -25,33 +24,38 @@ func TestBlameFile(t *testing.T) {
 	}
 	expCommits := map[string]Commit{
 		"26e6e00a6bfd5430a5a8840a543465dc8cac801e": {
-			ID:     "26e6e00a6bfd5430a5a8840a543465dc8cac801e",
-			Author: Author{Name: "Beyang Liu", Email: "beyang.liu@gmail.com"},
+			ID:         "26e6e00a6bfd5430a5a8840a543465dc8cac801e",
+			Author:     Author{Name: "Beyang Liu", Email: "beyang.liu@gmail.com"},
+			AuthorDate: mustParseTime("Mon Oct 7 18:13:58 2013 -0700"),
 		},
 		"c497236203ba6400272034a9db7be00859c9863d": {
-			ID:     "c497236203ba6400272034a9db7be00859c9863d",
-			Author: Author{Name: "Beyang Liu", Email: "beyang.liu@gmail.com"},
+			ID:         "c497236203ba6400272034a9db7be00859c9863d",
+			Author:     Author{Name: "Beyang Liu", Email: "beyang.liu@gmail.com"},
+			AuthorDate: mustParseTime("Mon Oct 7 18:14:46 2013 -0700"),
 		},
 		"7653ddfbc69a584272a18fe5e675b95025e84bb9": {
-			ID:     "7653ddfbc69a584272a18fe5e675b95025e84bb9",
-			Author: Author{Name: "Ricky Bobby", Email: "ricky@bobby.com"},
+			ID:         "7653ddfbc69a584272a18fe5e675b95025e84bb9",
+			Author:     Author{Name: "Ricky Bobby", Email: "ricky@bobby.com"},
+			AuthorDate: mustParseTime("Mon Oct 7 19:00:15 2013 -0700"),
 		},
 		"d858245d0690b83df437ad830ab1e971d389d68d": {
-			ID:     "d858245d0690b83df437ad830ab1e971d389d68d",
-			Author: Author{Name: "Sam Hamilton", Email: "sam@salinas.com"},
+			ID:         "d858245d0690b83df437ad830ab1e971d389d68d",
+			Author:     Author{Name: "Sam Hamilton", Email: "sam@salinas.com"},
+			AuthorDate: mustParseTime("Tue Oct 8 09:29:12 2013 -0700"),
 		},
 		"496529633d7c1e8359db63aa3d297359479479ff": {
-			ID:     "496529633d7c1e8359db63aa3d297359479479ff",
-			Author: Author{Name: "Beyang Liu", Email: "beyang.liu@gmail.com"},
+			ID:         "496529633d7c1e8359db63aa3d297359479479ff",
+			Author:     Author{Name: "Beyang Liu", Email: "beyang.liu@gmail.com"},
+			AuthorDate: mustParseTime("Thu Oct 10 13:59:56 2013 -0700"),
 		},
 	}
 
 	if !reflect.DeepEqual(expHunks, hunks) {
-		t.Errorf("Hunks don't match: %s", strings.Join(pretty.Diff(expHunks, hunks), "\n"))
+		t.Errorf("Hunks don't match: %+v != %+v", expHunks, hunks)
 	}
 
 	if !reflect.DeepEqual(expCommits, commits) {
-		t.Errorf("Commits don't match: %s", strings.Join(pretty.Diff(expCommits, commits), "\n"))
+		t.Errorf("Commits don't match: %+v != %+v", expCommits, commits)
 	}
 }
 
@@ -63,15 +67,16 @@ func TestBlameEmptyFile(t *testing.T) {
 	expHunks := []Hunk{{CommitID: "ba4f3f4147a2843eb88712b450ea28ec221f3490", LineStart: 0, LineEnd: 0, CharStart: 0, CharEnd: 0}}
 	expCommits := map[string]Commit{
 		"ba4f3f4147a2843eb88712b450ea28ec221f3490": {
-			ID:     "ba4f3f4147a2843eb88712b450ea28ec221f3490",
-			Author: Author{Name: "Beyang Liu", Email: "beyang.liu@gmail.com"},
+			ID:         "ba4f3f4147a2843eb88712b450ea28ec221f3490",
+			Author:     Author{Name: "Beyang Liu", Email: "beyang.liu@gmail.com"},
+			AuthorDate: mustParseTime("Fri Oct 11 18:28:10 2013 -0700"),
 		},
 	}
 	if !reflect.DeepEqual(expHunks, hunks) {
-		t.Errorf("Hunks don't match: %s", strings.Join(pretty.Diff(expHunks, hunks), "\n"))
+		t.Errorf("Hunks don't match: %+v != %+v", expHunks, hunks)
 	}
 	if !reflect.DeepEqual(expCommits, commits) {
-		t.Errorf("Commits don't match: %s", strings.Join(pretty.Diff(expCommits, commits), "\n"))
+		t.Errorf("Commits don't match: %+v != %+v", expCommits, commits)
 	}
 }
 
@@ -143,4 +148,13 @@ func TestBlameQuery(t *testing.T) {
 			t.Errorf("On query %d:%d, expected error, but got none", query[0], query[1])
 		}
 	}
+}
+
+func mustParseTime(s string) time.Time {
+	gitDateFormat := "Mon Jan 2 15:04:05 2006 -0700"
+	t, err := time.Parse(gitDateFormat, s)
+	if err != nil {
+		panic("failed to parse time: " + err.Error())
+	}
+	return t
 }


### PR DESCRIPTION
This PR is a backwards-compatible change that adds an `AuthorDate` field to the `Commit` struct and populates it with data from the `author-time` field in `git blame` output.

I had to remove github.com/kr/pretty because it panics when you try to `pretty.Diff` a `time.Time` object (because of unexported fields).
